### PR TITLE
Fix: SonarCloud tasks requires DotNet Core 2.x when running 3.x p…

### DIFF
--- a/azDevOps/azure/templates/jobs/build-dotnet.yml
+++ b/azDevOps/azure/templates/jobs/build-dotnet.yml
@@ -96,6 +96,7 @@ jobs:
             displayName: 'Use .NET Core SDK 2.2.x For SonarCloud'
             inputs:
               version: '2.2.x'
+              packageType: runtime
 
           - task: SonarCloudPrepare@1
             inputs:

--- a/azDevOps/azure/templates/jobs/build-dotnet.yml
+++ b/azDevOps/azure/templates/jobs/build-dotnet.yml
@@ -77,6 +77,9 @@ jobs:
           version: ${{ parameters.dotnet_core_version }}
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
+      - script: dotnet --list-sdks
+        displayName: 'Check dotnet sdks installed'
+
       # SonarCloud Start
       - ${{ if eq(parameters.static_code_analysis, true) }}:
           # Set Sonar extra properties based on parameter input
@@ -88,6 +91,11 @@ jobs:
               fi
               echo "##vso[task.setvariable variable=Sonar_extraProperties]$EXTRA_PROPERTIES"
             displayName: 'Set Sonar Extra Properties variable'
+
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core SDK 2.2.x For SonarCloud'
+            inputs:
+              version: '2.2.x'
 
           - task: SonarCloudPrepare@1
             inputs:

--- a/azDevOps/azure/templates/jobs/build-dotnet.yml
+++ b/azDevOps/azure/templates/jobs/build-dotnet.yml
@@ -40,7 +40,7 @@ parameters:
   build_file_path: ''
   build_file_artefact: ''
   # .NET Core version variable
-  dotnet_core_version: '2.2.x'
+  dotnet_core_version: '2.2.x' 
 
 jobs:
   - job: BuildDotNet
@@ -70,12 +70,12 @@ jobs:
           login_kubernetes: false
           devops_artefact_name: '${{ parameters.devops_artefact_name }}'
 
-      - task: UseDotNet@2
+      - task: UseDotNet@2 
         displayName: 'Use .NET Core SDK ${{ parameters.dotnet_core_version }}'
         inputs:
           packageType: sdk
           version: ${{ parameters.dotnet_core_version }}
-          installationPath: $(Agent.ToolsDirectory)/dotnet
+          installationPath: $(Agent.ToolsDirectory)/dotnet 
 
       - script: dotnet --list-sdks
         displayName: 'Check dotnet sdks installed'

--- a/azDevOps/azure/templates/jobs/deploy-dotnet.yml
+++ b/azDevOps/azure/templates/jobs/deploy-dotnet.yml
@@ -17,6 +17,7 @@ parameters:
   appinsights_enabled: false
   appinsights_accountName: ''
   performance_test: false
+  dotnet_core_version: '2.2.x'
 
 jobs:
 - deployment: ${{ parameters.environment }}
@@ -126,6 +127,18 @@ jobs:
             arguments: ./${{ parameters.kubernetes_kustomize_filepath }}
             workingDirectory: $(Pipeline.Workspace)/${{ parameters.build_artefact }}
             failOnStderr: true
+
+## Install dotnet core version based on project dependencies
+        - ${{ if or(eq(parameters.functional_test, true), eq(parameters.smoke_test, true)) }}:
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core SDK ${{ parameters.dotnet_core_version }}'
+            inputs:
+              packageType: sdk
+              version: ${{ parameters.dotnet_core_version }}
+              installationPath: $(Agent.ToolsDirectory)/dotnet
+
+          - script: dotnet --list-sdks
+            displayName: 'Check dotnet sdks installed'
 
 ## Functional Testing
         - ${{ if eq(parameters.functional_test, true) }}:


### PR DESCRIPTION
SonarCloud tasks uses dotnet core 2.2 to analyze the project.

For this reason, when using the pipeline with .net core 3.x, it will fail

This PR add task to install dotnet core 2.x for sonar cloud