### PR TITLE
Bug: support private and public npm packages

### DIFF
--- a/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
@@ -24,9 +24,9 @@ steps:
   - task: Npm@1
     displayName: "Build: Run audit"
     inputs:
-      command: 'custom' # Options: install, publish, custom
+      command: 'custom'
       workingDir: ${{ parameters.workingDirectory }}
       customCommand: 'audit'
       # if undefined will default to npmjs
-      ${{ if ne(parameters.customRegistry, '') }}
+      ${{ if ne(parameters.customRegistry, '') }}:
         customRegistry: ${{ parameters.customRegistry }}

--- a/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
@@ -11,13 +11,22 @@ parameters:
   customRegistry: ""
 
 steps:
-  # Ensure Node.js 12 is actives
+  # Ensure Correct version of Node.js is actives
   - task: NodeTool@0
     inputs:
       versionSpec: ${{ parameters.versionSpec }}
+      # this parameter does nothing for this task - can be removed
       customRegistry: ${{ parameters.customRegistry }}
     displayName: "Use Node.js ${{ parameters.versionSpec }}"
 
-  - script: npm audit
+  # npm
+  # Install and publish npm packages, or run an npm command. Supports npmjs.com and authenticated registries like Azure Artifacts.
+  - task: Npm@1
     displayName: "Build: Run audit"
-    workingDirectory: ${{ parameters.workingDirectory }}
+    inputs:
+      command: 'custom' # Options: install, publish, custom
+      workingDir: ${{ parameters.workingDirectory }}
+      customCommand: 'audit'
+      # if undefined will default to npmjs
+      ${{ if ne(parameters.customRegistry, '') }}
+        customRegistry: ${{ parameters.customRegistry }}

--- a/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
@@ -11,7 +11,7 @@ parameters:
   customRegistry: ""
 
 steps:
-  # Ensure Correct version of Node.js is actives
+  # Ensure Correct version of Node.js is set
   - task: NodeTool@0
     inputs:
       versionSpec: ${{ parameters.versionSpec }}

--- a/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-audit-dependencies-node.yml
@@ -8,13 +8,14 @@
 parameters:
   versionSpec: ""
   workingDirectory: ""
+  customRegistry: ""
 
 steps:
   # Ensure Node.js 12 is actives
   - task: NodeTool@0
     inputs:
       versionSpec: ${{ parameters.versionSpec }}
-      customRegistry: "useNpmrc"
+      customRegistry: ${{ parameters.customRegistry }}
     displayName: "Use Node.js ${{ parameters.versionSpec }}"
 
   - script: npm audit

--- a/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
@@ -21,7 +21,7 @@ steps:
   # If we are using a private or custom npm registry, then we must authenticate to embellish the .npmrc file with the credentials
   # This is required for task runners, e.g. building docker images in bash.
   # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/npm-authenticate for more information
-  - ${{ if eq(parameters.customRegistry, "useNpmrc") }}:
+  - ${{ if eq(parameters.customRegistry, 'useNpmrc') }}:
       - task: npmAuthenticate@0
         displayName: "Registry: Authenticate to custom registry"
         inputs:

--- a/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
@@ -34,7 +34,8 @@ steps:
       command: "install"
       workingDir: ${{ parameters.workingDirectory }}
       verbose: false
-      customRegistry: ${{ parameters.customRegistry }}
+      ${{ if ne(parameters.customRegistry, '') }}:
+        customRegistry: ${{ parameters.customRegistry }}
 
   - script: |
       npm run build

--- a/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
@@ -8,21 +8,24 @@
 parameters:
   versionSpec: ""
   workingDirectory: ""
+  customRegistry: ""
 
 steps:
   # Ensure Node.js 12 is active
   - task: NodeTool@0
     inputs:
       versionSpec: ${{ parameters.versionSpec }}
-      customRegistry: "useNpmrc"
+      customRegistry: ${{ parameters.customRegistry }}
     displayName: "Use Node.js ${{ parameters.versionSpec }}"
 
   # If we are using a private or custom npm registry, then we must authenticate to embellish the .npmrc file with the credentials
   # This is required for task runners, e.g. building docker images in bash.
   # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/npm-authenticate for more information
-  - task: npmAuthenticate@0
-    inputs:
-      workingFile: ${{ parameters.workingDirectory }}/.npmrc
+  - ${{ if eq(parameters.customRegistry, "useNpmrc") }}:
+    - task: npmAuthenticate@0
+      displayName: "Registry: Authenticate to custom registry"
+      inputs:
+        workingFile: ${{ parameters.workingDirectory }}/.npmrc
 
   - task: Npm@1
     displayName: "Build: Install Dev Dependencies"
@@ -30,7 +33,7 @@ steps:
       command: "install" # Options: install, publish, custom
       workingDir: ${{ parameters.workingDirectory }}
       verbose: false
-      customRegistry: "useNpmrc"
+      customRegistry: ${{ parameters.customRegistry }}
 
   - script: |
       npm run build

--- a/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-install-dependencies-node.yml
@@ -22,15 +22,16 @@ steps:
   # This is required for task runners, e.g. building docker images in bash.
   # See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/npm-authenticate for more information
   - ${{ if eq(parameters.customRegistry, "useNpmrc") }}:
-    - task: npmAuthenticate@0
-      displayName: "Registry: Authenticate to custom registry"
-      inputs:
-        workingFile: ${{ parameters.workingDirectory }}/.npmrc
+      - task: npmAuthenticate@0
+        displayName: "Registry: Authenticate to custom registry"
+        inputs:
+          workingFile: ${{ parameters.workingDirectory }}/.npmrc
 
   - task: Npm@1
     displayName: "Build: Install Dev Dependencies"
     inputs:
-      command: "install" # Options: install, publish, custom
+      # Options: install, publish, custom
+      command: "install"
       workingDir: ${{ parameters.workingDirectory }}
       verbose: false
       customRegistry: ${{ parameters.customRegistry }}

--- a/azDevOps/azure/templates/v2/steps/build-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-node.yml
@@ -56,7 +56,7 @@ steps:
 
   # Audit dependencies
   # Important: can only audit public packages in Azure Pipelines
-  - ${{ if ne(parameters.customRegistry, "useNpmrc") }}:
+  - ${{ if ne(parameters.customRegistry, 'useNpmrc') }}:
       - template: ./build-audit-dependencies-node.yml
         parameters:
           versionSpec: ${{ parameters.versionSpec }}
@@ -143,13 +143,6 @@ steps:
           git push origin v${{ parameters.git_release_tag }}
         displayName: Git Tag release
         workingDirectory: ${{ parameters.project_root_dir }}
-
-  # Do Lerna release
-  - ${{ if eq(parameters.publish_packages_lerna, true) }}:
-      - bash: |
-          ${{ parameters.lerna_command }}
-        displayName: Lerna Publish
-        workingDirectory: ${{ parameters.lerna_rootDir }}
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/azDevOps/azure/templates/v2/steps/build-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-node.yml
@@ -5,6 +5,8 @@ parameters:
   project_root_dir: ""
   dependsOn: "GetPackage"
   download_devops: true
+  # Custom registry (eg. private)
+  customRegistry: ""
   # Docker Config
   docker_build: true
   docker_build_additional_args: ""
@@ -16,7 +18,6 @@ parameters:
   vulnerability_scan: false
   vulnerability_workdir: ""
   #  Static Code Analysis
-  build_audit: false
   static_code_analysis: false
   static_code_analysis_build_path: ""
   Sonar_serviceConnection: ""
@@ -54,17 +55,20 @@ steps:
       login_azure: true
 
   # Audit dependencies
-  - ${{ if eq(parameters.build_audit, true) }}:
+  # Important: can only audit public packages in Azure Pipelines
+  - ${{ if ne(parameters.customRegistry, "useNpmrc") }}:
       - template: ./build-audit-dependencies-node.yml
         parameters:
           versionSpec: ${{ parameters.versionSpec }}
           workingDirectory: ${{ parameters.project_root_dir }}
+          customRegistry: ${{ parameters.project_root_dir }}
 
   # Install dependencies
   - template: ./build-install-dependencies-node.yml
     parameters:
       versionSpec: ${{ parameters.versionSpec }}
       workingDirectory: ${{ parameters.project_root_dir }}
+      customRegistry: ${{ parameters.customRegistry }}
 
   # Linting and formatting validation
   - ${{ if eq(parameters.lint_formatting, true) }}:
@@ -73,6 +77,7 @@ steps:
           versionSpec: ${{ parameters.versionSpec }}
           workingDirectory: ${{ parameters.project_root_dir }}
           lintingSharedConfigPackage: ${{ parameters.shared_eslint_config }}
+          customRegistry: ${{ parameters.customRegistry }}
 
   # Linting and unit tests
   - ${{ if eq(parameters.unit_test, true) }}:
@@ -116,7 +121,7 @@ steps:
           command: "custom" # Options: install, publish, custom
           customCommand: "ci --only=prod"
           workingDirectory: ${{ parameters.project_root_dir }}
-          customRegistry: "useNpmrc"
+          customRegistry: ${{ parameters.customRegistry }}
 
   # Build Docker Image, Scan and Push to Repository
   - ${{ if eq(parameters.docker_build, true) }}:

--- a/azDevOps/azure/templates/v2/steps/build-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-node.yml
@@ -32,6 +32,7 @@ parameters:
   # Testing
   unit_test: true
   contract_test: true
+  audit_test: false
   contract_check_can_deploy: false
   e2e_test: true
   e2e_env_vars: {}
@@ -55,13 +56,14 @@ steps:
       login_azure: true
 
   # Audit dependencies
-  # Important: can only audit public packages in Azure Pipelines
-  - ${{ if ne(parameters.customRegistry, 'useNpmrc') }}:
+  # Important: Down to the user to ensure that the registry they are using
+  # can support `npm audit`
+  - ${{ if eq(parameters.audit_test, true) }}:
       - template: ./build-audit-dependencies-node.yml
         parameters:
           versionSpec: ${{ parameters.versionSpec }}
           workingDirectory: ${{ parameters.project_root_dir }}
-          customRegistry: ${{ parameters.project_root_dir }}
+          customRegistry: ${{ parameters.customRegistry }}
 
   # Install dependencies
   - template: ./build-install-dependencies-node.yml

--- a/azDevOps/azure/templates/v2/steps/build-node.yml
+++ b/azDevOps/azure/templates/v2/steps/build-node.yml
@@ -26,7 +26,7 @@ parameters:
   Sonar_projectKey: ""
   Sonar_projectName: ""
   Sonar_projectVersion: ""
-  #Linting and formatting validation
+  # Linting and formatting validation
   lint_formatting: ""
   shared_eslint_config: ""
   # Testing
@@ -118,7 +118,8 @@ steps:
       - task: Npm@1
         displayName: Build on ADO using custom feeds
         inputs:
-          command: "custom" # Options: install, publish, custom
+          # Options: install, publish, custom
+          command: "custom"
           customCommand: "ci --only=prod"
           workingDirectory: ${{ parameters.project_root_dir }}
           customRegistry: ${{ parameters.customRegistry }}

--- a/azDevOps/azure/templates/v2/steps/deploy-provisioning-terraform.yml
+++ b/azDevOps/azure/templates/v2/steps/deploy-provisioning-terraform.yml
@@ -1,13 +1,13 @@
 parameters:
-  # Terraform Basic Config
+  # Terraform Basic Config
   terraform_artefact_name: "terraform"
-  #  Terraform State Config
+  # Terraform State Config
   terraform_state_rg: ""
   terraform_state_storage: ""
   terraform_state_container: ""
   terraform_state_key: ""
   terraform_state_workspace: ""
-  # Global Config
+  # Global Config
   company: "amido"
   project: "stacks"
   domain: ""

--- a/azDevOps/azure/templates/v2/steps/test-static-validate-node.yml
+++ b/azDevOps/azure/templates/v2/steps/test-static-validate-node.yml
@@ -22,7 +22,8 @@ steps:
   - task: Npm@1
     displayName: "Build: Install Peer Dependencies"
     inputs:
-      command: "custom" # Options: install, publish, custom
+      # Options: install, publish, custom
+      command: "custom"
       customCommand: "npx install-peerdeps --save-dev ${{ parameters.workingDirectory }}"
       workingDir: ${{ parameters.workingDirectory }}
       verbose: true

--- a/azDevOps/azure/templates/v2/steps/test-static-validate-node.yml
+++ b/azDevOps/azure/templates/v2/steps/test-static-validate-node.yml
@@ -9,13 +9,14 @@ parameters:
   versionSpec: ""
   workingDirectory: ""
   lintingSharedConfigPackage: ""
+  customRegistry: ""
 
 steps:
   # Ensure Node.js 12 is actives
   - task: NodeTool@0
     inputs:
       versionSpec: ${{ parameters.versionSpec }}
-      customRegistry: "useNpmrc"
+      customRegistry: ${{ parameters.customRegistry }}
     displayName: "Use Node.js ${{ parameters.versionSpec }}"
 
   - task: Npm@1
@@ -25,7 +26,7 @@ steps:
       customCommand: "npx install-peerdeps --save-dev ${{ parameters.workingDirectory }}"
       workingDir: ${{ parameters.workingDirectory }}
       verbose: true
-      customRegistry: "useNpmrc"
+      customRegistry: ${{ parameters.customRegistry }}
 
   # Run tests with Jest
   - script: npm run validate


### PR DESCRIPTION
To ensure that our steps can be used for both private and public registries, made the `customRegistry` param input an optional.

This will be used to check if we can audit the packages the pipeline also. Currently Azure Pipelines doesn't support auditing of private packages hosted in Azure.

Conditional to check if we need to authenticate for installation and publishing.