### PR TITLE
Run testcafe on windows vmimage

### DIFF
--- a/azDevOps/azure/templates/v2/steps/deploy-node.yml
+++ b/azDevOps/azure/templates/v2/steps/deploy-node.yml
@@ -12,9 +12,6 @@ parameters:
   docker_containerregistryname: ""
   test_artefact: "tests"
   test_baseurl: ""
-  testcafe_e2e_test: true
-  testcafe_e2e_env_vars: {}
-  testcafe_workdir: ""
   functional_test: false
   smoke_test: false
   kubernetes_clusterrg: ""

--- a/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
+++ b/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
@@ -6,20 +6,20 @@
 ############################################################################################################
 
 parameters:
-  testcafe_e2e_env_vars: {}
-  testcafe_workdir: ''
+  env_vars: {}
+  workingDirectory: ''
   testcafe_browser_list: 'all'
 
 steps:
   # Install test runtime dependencies (not installing modules listed in devDependencies)
   - script: npm install --production
     displayName: 'Install test dependencies'
-    workingDirectory: ${{ parameters.testcafe_workdir }}
+    workingDirectory: ${{ parameters.workingDirectory }}
 
   # Run tests with Testcafe
   - script: npm run test:e2e -- ${{ parameters.testcafe_browser_list }}
     displayName: 'Test: Run Testcafe tests against specified browsers'
-    workingDirectory: ${{ parameters.testcafe_workdir }}
+    workingDirectory: ${{ parameters.workingDirectory }}
     env:
       ${{ each var in parameters.env_vars }}:
         ${{ var.key }}: ${{ var.value }}
@@ -28,7 +28,7 @@ steps:
   - task: PublishPipelineArtifact@1
     inputs:
       artifactName: 'screenshots'
-      targetPath: '${{ parameters.testcafe_workdir }}/screenshots'
+      targetPath: '${{ parameters.workingDirectory }}/screenshots'
     displayName: 'Publish Screenshots (TestCafe)'
     condition: failed()
 

--- a/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
+++ b/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
@@ -6,20 +6,20 @@
 ############################################################################################################
 
 parameters:
-  env_vars: {}
-  workingDirectory: ''
+  testcafe_e2e_env_vars: {}
+  testcafe_workdir: ''
   testcafe_browser_list: 'all'
 
 steps:
   # Install test runtime dependencies (not installing modules listed in devDependencies)
   - script: npm install --production
     displayName: 'Install test dependencies'
-    workingDirectory: ${{ parameters.workingDirectory }}
+    workingDirectory: ${{ parameters.testcafe_workdir }}
 
   # Run tests with Testcafe
   - script: npm run test:e2e -- ${{ parameters.testcafe_browser_list }}
     displayName: 'Test: Run Testcafe tests against specified browsers'
-    workingDirectory: ${{ parameters.workingDirectory }}
+    workingDirectory: ${{ parameters.testcafe_workdir }}
     env:
       ${{ each var in parameters.env_vars }}:
         ${{ var.key }}: ${{ var.value }}
@@ -28,7 +28,7 @@ steps:
   - task: PublishPipelineArtifact@1
     inputs:
       artifactName: 'screenshots'
-      targetPath: '${{ parameters.workingDirectory }}/screenshots'
+      targetPath: '${{ parameters.testcafe_workdir }}/screenshots'
     displayName: 'Publish Screenshots (TestCafe)'
     condition: failed()
 
@@ -36,7 +36,7 @@ steps:
   - task: PublishTestResults@2
     inputs:
       testRunner: xUnit
-      testResultsFiles: 'testcafe-xunit-test-report.xml'
+      testResultsFiles: '**/testcafe-xunit-test-report.xml'
       testRunTitle: 'TestCafe Tests'
     displayName: 'Publish test results'
     condition: succeededOrFailed()

--- a/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
+++ b/azDevOps/azure/templates/v2/steps/test-functional-testcafe.yml
@@ -1,13 +1,14 @@
 ############################################################################################################
 # desc: Runs the functional (e2e) tests on a deployed webapp with Testcafe
-# params: Env vars, Node version, workingDirectory, build_number
-# return: Publishes test results, screenshots and video recordings
-# pre-reqs: dependency installation, build webapp
+# params: Env vars, workingDirectory, testcafe_browser_list (default to all)
+# return: Publishes test results, screenshots
+# pre-reqs: deployed webapp
 ############################################################################################################
 
 parameters:
   env_vars: {}
   workingDirectory: ''
+  testcafe_browser_list: 'all'
 
 steps:
   # Install test runtime dependencies (not installing modules listed in devDependencies)
@@ -15,10 +16,9 @@ steps:
     displayName: 'Install test dependencies'
     workingDirectory: ${{ parameters.workingDirectory }}
 
-  # Run the tests in a Testcafe Docker container that has installed browsers
-  - bash: |
-      docker run -e APP_BASE_URL=$APP_BASE_URL -e APP_BASE_PATH=$APP_BASE_PATH -e MENU_API_URL=$MENU_API_URL -e NODE_ENV=$NODE_ENV -it -v $(pwd):/tests testcafe/testcafe all /tests/**/*.test.cf.ts
-    displayName: 'Test: Run Testcafe tests against all browsers in container'
+  # Run tests with Testcafe
+  - script: npm run test:e2e -- ${{ parameters.testcafe_browser_list }}
+    displayName: 'Test: Run Testcafe tests against specified browsers'
     workingDirectory: ${{ parameters.workingDirectory }}
     env:
       ${{ each var in parameters.env_vars }}:


### PR DESCRIPTION
To ensure we can support all the required browsers, we will be changing the functional E2Es tests to be in another post deploy job, and run on a windows vm. This is to ensure we support IE.