### PR TITLE
Feat/add plan only switch

### DIFF
--- a/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
+++ b/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
@@ -46,18 +46,18 @@ steps:
   #   inputs:
   #     instructions: 'reject or resume'
   #     onTimeout: 'reject'
- - ${{ if eq(parameters.terraform_plan_only, false) }}:
-  - bash: terraform apply tfplan
-    displayName: 'Terraform: Apply'
-    workingDirectory: ${{ parameters.working_dir }}
-    env:
-      # AUTH PARAMS
-      ${{ each var in parameters.terraform_auth_properties }}:
-        ${{ var.key }}: ${{ var.value }}
-      # Extra Parameters
-      # Business specific vars passed from pipeline
-      ${{ each var in parameters.terraform_extra_properties }}:
-        ${{ var.key }}: ${{ var.value }}
+  - ${{ if eq(parameters.terraform_plan_only, false) }}:
+    - bash: terraform apply tfplan
+      displayName: 'Terraform: Apply'
+      workingDirectory: ${{ parameters.working_dir }}
+      env:
+        # AUTH PARAMS
+        ${{ each var in parameters.terraform_auth_properties }}:
+          ${{ var.key }}: ${{ var.value }}
+        # Extra Parameters
+        # Business specific vars passed from pipeline
+        ${{ each var in parameters.terraform_extra_properties }}:
+          ${{ var.key }}: ${{ var.value }}
 
   - bash: ${{ parameters.terraform_output_commands }}
     displayName: 'Terraform: Write Outputs to Variables'

--- a/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
+++ b/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
@@ -17,7 +17,7 @@ parameters:
   terraform_extra_properties: {}
   terraform_output_commands: ''
   terraform_plan_only: false
-  
+
 steps:
   - template: ./deploy-terraform-init-generic.yml
     parameters:
@@ -46,7 +46,7 @@ steps:
   #   inputs:
   #     instructions: 'reject or resume'
   #     onTimeout: 'reject'
-- ${{ if eq(parameters.terraform_plan_only, false) }}:
+ - ${{ if eq(parameters.terraform_plan_only, false) }}:
   - bash: terraform apply tfplan
     displayName: 'Terraform: Apply'
     workingDirectory: ${{ parameters.working_dir }}

--- a/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
+++ b/azDevOps/azure/templates/v2/steps/deploy-terraform-meta-generic.yml
@@ -16,7 +16,8 @@ parameters:
   # Terraform Resource Specific Config
   terraform_extra_properties: {}
   terraform_output_commands: ''
-
+  terraform_plan_only: false
+  
 steps:
   - template: ./deploy-terraform-init-generic.yml
     parameters:
@@ -45,7 +46,7 @@ steps:
   #   inputs:
   #     instructions: 'reject or resume'
   #     onTimeout: 'reject'
-
+- ${{ if eq(parameters.terraform_plan_only, false) }}:
   - bash: terraform apply tfplan
     displayName: 'Terraform: Apply'
     workingDirectory: ${{ parameters.working_dir }}


### PR DESCRIPTION
Adding `terraform_plan_only` switch to the template in order to be able to run terraform plan only.  Default value set in the template is `false` 